### PR TITLE
[Dependency bump] Bump cdap and hadoop versions to resolve vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,8 +27,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cdap.version>6.1.0-SNAPSHOT</cdap.version>
-    <hadoop.version>2.3.0</hadoop.version>
+    <cdap.version>6.8.0</cdap.version>
+    <hadoop.version>2.10.2</hadoop.version>
     <!-- properties for script build step that creates the config files for the artifacts -->
     <widgets.dir>widgets</widgets.dir>
     <docs.dir>docs</docs.dir>
@@ -56,7 +56,7 @@
     </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
-      <artifactId>cdap-data-pipeline</artifactId>
+      <artifactId>cdap-data-pipeline2_2.11</artifactId>
       <version>${cdap.version}</version>
       <scope>test</scope>
     </dependency>
@@ -243,8 +243,8 @@
         <version>1.1.0</version>
         <configuration>
           <cdapArtifacts>
-            <parent>system:cdap-data-pipeline[6.1.0-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
-            <parent>system:cdap-data-streams[6.1.0-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
+            <parent>system:cdap-data-pipeline[6.8.0,7.0.0-SNAPSHOT)</parent>
+            <parent>system:cdap-data-streams[6.8.0,7.0.0-SNAPSHOT)</parent>
           </cdapArtifacts>
         </configuration>
         <executions>


### PR DESCRIPTION
Hadoop version 2.3.0 has a transitive dependency on log4j as follows:

    [INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ file-appender ---
    [INFO] io.cdap.plugin.fileappend:file-appender:jar:1.2.0-SNAPSHOT
    [INFO] \- org.apache.hadoop:hadoop-mapreduce-client-core:jar:2.3.0:provided
    [INFO]    \- org.apache.hadoop:hadoop-yarn-common:jar:2.3.0:provided
    [INFO]       \- log4j:log4j:jar:1.2.17:provided

### Changes:
- Bumped hadoop to version 2.10.2
- Updated cdap to latest version

Maven build and unit tests succeeded. 
